### PR TITLE
Fix ITAD API 404 by migrating to V3 endpoint (Vibe Kanban)

### DIFF
--- a/scripts/populate_prices_async.py
+++ b/scripts/populate_prices_async.py
@@ -361,7 +361,7 @@ class AsyncPricePopulator:
 
                     if game_id:
                         # Get price data
-                        prices_url = f"https://api.isthereanydeal.com/games/lowest/v2?key={ITAD_API_KEY}&country=US"
+                        prices_url = f"https://api.isthereanydeal.com/games/prices/v3?key={ITAD_API_KEY}&country=US&shops=61"
                         prices_response = await self.make_request_with_retry(
                             prices_url,
                             method="POST",
@@ -377,11 +377,11 @@ class AsyncPricePopulator:
                             if (
                                 prices_data
                                 and len(prices_data) > 0
-                                and "price" in prices_data[0]
+                                and "historyLow" in prices_data[0]
                             ):
-                                price_info = prices_data[0]["price"]
-                                price_amount = price_info.get("amount")
-                                shop_name = prices_data[0].get("shop", {}).get("name", "Unknown Store")
+                                history_low = prices_data[0]["historyLow"].get("all", {})
+                                price_amount = history_low.get("amount")
+                                shop_name = history_low.get("shop", {}).get("name", "Historical Low (All Stores)")
                                 
                                 if price_amount is not None:
                                     price_data = {
@@ -414,7 +414,7 @@ class AsyncPricePopulator:
                             game_id = search_data[0].get("id")
                             if game_id:
                                 # Get price data
-                                prices_url = f"https://api.isthereanydeal.com/games/lowest/v2?key={ITAD_API_KEY}&country=US"
+                                prices_url = f"https://api.isthereanydeal.com/games/prices/v3?key={ITAD_API_KEY}&country=US&shops=61"
                                 prices_response = await self.make_request_with_retry(
                                     prices_url,
                                     method="POST",
@@ -430,11 +430,11 @@ class AsyncPricePopulator:
                                     if (
                                         prices_data
                                         and len(prices_data) > 0
-                                        and "price" in prices_data[0]
+                                        and "historyLow" in prices_data[0]
                                     ):
-                                        price_info = prices_data[0]["price"]
-                                        price_amount = price_info.get("amount")
-                                        shop_name = prices_data[0].get("shop", {}).get("name", "Unknown Store")
+                                        history_low = prices_data[0]["historyLow"].get("all", {})
+                                        price_amount = history_low.get("amount")
+                                        shop_name = history_low.get("shop", {}).get("name", "Historical Low (All Stores)")
 
                                         if price_amount is not None:
                                             price_data = {

--- a/scripts/populate_prices_optimized.py
+++ b/scripts/populate_prices_optimized.py
@@ -409,7 +409,7 @@ class OptimizedPricePopulator:
 
                 if game_id:
                     # Get price data
-                    prices_url = f"https://api.isthereanydeal.com/games/lowest/v2?key={ITAD_API_KEY}&country=US"
+                    prices_url = f"https://api.isthereanydeal.com/games/prices/v3?key={ITAD_API_KEY}&country=US&shops=61"
                     prices_response = self.make_request_with_retry(
                         prices_url, method="POST", json_data=[game_id], api_type="itad"
                     )
@@ -422,11 +422,11 @@ class OptimizedPricePopulator:
                         if (
                             prices_data
                             and len(prices_data) > 0
-                            and "price" in prices_data[0]
+                            and "historyLow" in prices_data[0]
                         ):
-                            price_info = prices_data[0]["price"]
-                            price_amount = price_info.get("amount")
-                            shop_name = prices_data[0].get("shop", {}).get("name", "Unknown Store")
+                            history_low = prices_data[0]["historyLow"].get("all", {})
+                            price_amount = history_low.get("amount")
+                            shop_name = history_low.get("shop", {}).get("name", "Historical Low (All Stores)")
 
                             if price_amount is not None:
                                 cache_itad_price_enhanced(
@@ -464,7 +464,7 @@ class OptimizedPricePopulator:
                         game_id = search_data[0].get("id")
                         if game_id:
                             # Get price data
-                            prices_url = f"https://api.isthereanydeal.com/games/lowest/v2?key={ITAD_API_KEY}&country=US"
+                            prices_url = f"https://api.isthereanydeal.com/games/prices/v3?key={ITAD_API_KEY}&country=US&shops=61"
                             prices_response = self.make_request_with_retry(
                                 prices_url,
                                 method="POST",
@@ -480,11 +480,11 @@ class OptimizedPricePopulator:
                                 if (
                                     prices_data
                                     and len(prices_data) > 0
-                                    and "price" in prices_data[0]
+                                    and "historyLow" in prices_data[0]
                                 ):
-                                    price_info = prices_data[0]["price"]
-                                    price_amount = price_info.get("amount")
-                                    shop_name = prices_data[0].get("shop", {}).get("name", "Unknown Store")
+                                    history_low = prices_data[0]["historyLow"].get("all", {})
+                                    price_amount = history_low.get("amount")
+                                    shop_name = history_low.get("shop", {}).get("name", "Historical Low (All Stores)")
 
                                     if price_amount is not None:
                                         cache_itad_price_enhanced(


### PR DESCRIPTION
## Summary
Migrates IsThereAnyDeal (ITAD) API usage from the deprecated \2\ endpoint to the current \3\ endpoint to resolve 404 errors.

## Changes
- Updated \src/familybot/lib/utils.py\ to fetch lowest historical prices using \https://api.isthereanydeal.com/games/prices/v3\.
- Updated \scripts/populate_prices_optimized.py\ and \scripts/populate_prices_async.py\ to utilize the new endpoint and parsing logic for both App ID and Name-based lookups.
- Adjusted response parsing to correctly handle the \3\ JSON structure, specifically extracting data from the \historyLow\ field.

## Motivation
The previously used \games/lowest/v2\ endpoint has been deprecated and decommissioned, resulting in \404 Client Error: Not Found\ failures when fetching price data.

This PR was written using [Vibe Kanban](https://vibekanban.com)